### PR TITLE
make command-space work

### DIFF
--- a/HalfKeyboard.xcodeproj/project.pbxproj
+++ b/HalfKeyboard.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,6 +12,7 @@
 		CD3978B624AD1FE100BFCB0D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CD3978B524AD1FE100BFCB0D /* Assets.xcassets */; };
 		CD3978B924AD1FE100BFCB0D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD3978B724AD1FE100BFCB0D /* Main.storyboard */; };
 		CD3978C224AD274900BFCB0D /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3978C124AD274900BFCB0D /* EventHandler.swift */; };
+		CD7B2C0526C7229800BC77BB /* KeyProcessor in Frameworks */ = {isa = PBXBuildFile; productRef = CD7B2C0426C7229800BC77BB /* KeyProcessor */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		CD4CAA762510F4FA0002D69B /* BuildNumber.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BuildNumber.xcconfig; sourceTree = "<group>"; };
 		CD4CAA792510F8770002D69B /* Global.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Global.xcconfig; sourceTree = "<group>"; };
 		CD4CAA7B2510F9A30002D69B /* buildnumber.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = buildnumber.rb; sourceTree = "<group>"; };
+		CD7B2C0026C7104400BC77BB /* Packages */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Packages; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -33,6 +35,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD7B2C0526C7229800BC77BB /* KeyProcessor in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -42,8 +45,10 @@
 		CD3978A524AD1FE100BFCB0D = {
 			isa = PBXGroup;
 			children = (
+				CD7B2C0026C7104400BC77BB /* Packages */,
 				CD3978B024AD1FE100BFCB0D /* HalfKeyboard */,
 				CD3978AF24AD1FE100BFCB0D /* Products */,
+				CD7B2C0126C7221A00BC77BB /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -96,6 +101,13 @@
 			path = Scripts;
 			sourceTree = "<group>";
 		};
+		CD7B2C0126C7221A00BC77BB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -113,6 +125,9 @@
 			dependencies = (
 			);
 			name = HalfKeyboard;
+			packageProductDependencies = (
+				CD7B2C0426C7229800BC77BB /* KeyProcessor */,
+			);
 			productName = HalfKeyboard;
 			productReference = CD3978AE24AD1FE100BFCB0D /* HalfKeyboard.app */;
 			productType = "com.apple.product-type.application";
@@ -402,6 +417,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CD7B2C0426C7229800BC77BB /* KeyProcessor */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KeyProcessor;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CD3978A624AD1FE100BFCB0D /* Project object */;
 }

--- a/HalfKeyboard.xcodeproj/xcshareddata/xcschemes/KeyProcessor.xcscheme
+++ b/HalfKeyboard.xcodeproj/xcshareddata/xcschemes/KeyProcessor.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Packages">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KeyProcessorTests"
+               BuildableName = "KeyProcessorTests"
+               BlueprintName = "KeyProcessorTests"
+               ReferencedContainer = "container:Packages">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/HalfKeyboard.xcodeproj/xcshareddata/xcschemes/KeyProcessor.xcscheme
+++ b/HalfKeyboard.xcodeproj/xcshareddata/xcschemes/KeyProcessor.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1170"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD3978AD24AD1FE100BFCB0D"
-               BuildableName = "HalfKeyboard.app"
-               BlueprintName = "HalfKeyboard"
-               ReferencedContainer = "container:HalfKeyboard.xcodeproj">
+               BlueprintIdentifier = "KeyProcessor"
+               BuildableName = "KeyProcessor"
+               BlueprintName = "KeyProcessor"
+               ReferencedContainer = "container:Packages">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -50,16 +50,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CD3978AD24AD1FE100BFCB0D"
-            BuildableName = "HalfKeyboard.app"
-            BlueprintName = "HalfKeyboard"
-            ReferencedContainer = "container:HalfKeyboard.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -67,16 +57,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CD3978AD24AD1FE100BFCB0D"
-            BuildableName = "HalfKeyboard.app"
-            BlueprintName = "HalfKeyboard"
-            ReferencedContainer = "container:HalfKeyboard.xcodeproj">
+            BlueprintIdentifier = "KeyProcessor"
+            BuildableName = "KeyProcessor"
+            BlueprintName = "KeyProcessor"
+            ReferencedContainer = "container:Packages">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/HalfKeyboard/EventHandler.swift
+++ b/HalfKeyboard/EventHandler.swift
@@ -33,12 +33,12 @@ final class EventHandler {
             }
             let unsafeProcessor = Unmanaged<KeyProcessor>.fromOpaque(userInfo).takeUnretainedValue()
             let events = unsafeProcessor.process(event: event, type: type)
-            events?.extras.forEach { event in
-                DispatchQueue.main.async {
-                    event.takeRetainedValue().post(tap: .cgSessionEventTap)
-                }
+
+            events?.preEvents.forEach { event in
+                event.takeUnretainedValue().tapPostEvent(proxy)
             }
-            return events?.main
+
+            return events?.mainEvent
         }
 
         // Set up the tap to intercept events

--- a/HalfKeyboard/EventHandler.swift
+++ b/HalfKeyboard/EventHandler.swift
@@ -1,13 +1,7 @@
-//
-//  EventHandler.swift
-//  HalfKeyboard
-//
-//  Created by Zev Eisenberg on 7/1/20.
-//
-
-import Foundation
-import CoreGraphics
 import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
+import KeyProcessor
 
 final class EventHandler {
 
@@ -19,8 +13,7 @@ final class EventHandler {
 
     private var isRunning = false
     private var eventTap: CFMachPort?
-    private var isSpaceDown: Bool = false
-    private var typedCharacterWhileSpaceWasDown: Bool = false
+    private let keyProcessor = KeyProcessor()
 
     // Lifecycle
 
@@ -34,12 +27,12 @@ final class EventHandler {
         // Intercept keyDown, keyUp, and flagsChanged events
         let mask: CGEventMask = 1 << CGEventType.keyDown.rawValue | 1 << CGEventType.keyUp.rawValue | 1 << CGEventType.flagsChanged.rawValue
 
-        let myCallbackTrampoline: CGEventTapCallBack = { (proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, userInfo: UnsafeMutableRawPointer?) in
+        let callbackTrampoline: CGEventTapCallBack = { (proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, userInfo: UnsafeMutableRawPointer?) in
             guard let userInfo = userInfo else {
                 return Unmanaged.passRetained(event)
             }
-            let unsafeSelf = Unmanaged<EventHandler>.fromOpaque(userInfo).takeUnretainedValue()
-            return unsafeSelf.handle(event: event, type: type)
+            let unsafeProcessor = Unmanaged<KeyProcessor>.fromOpaque(userInfo).takeUnretainedValue()
+            return unsafeProcessor.process(event: event, type: type)
         }
 
         // Set up the tap to intercept events
@@ -48,8 +41,8 @@ final class EventHandler {
             place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: mask,
-            callback: myCallbackTrampoline,
-            userInfo: Unmanaged.passUnretained(self).toOpaque()
+            callback: callbackTrampoline,
+            userInfo: Unmanaged.passUnretained(keyProcessor).toOpaque()
         )
 
         guard let eventTap = eventTap else {
@@ -73,108 +66,4 @@ final class EventHandler {
         isRunning = false
     }
 
-    func handle(event: CGEvent, type: CGEventType) -> Unmanaged<CGEvent>? {
-        let typedKeyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
-        switch typedKeyCode {
-        case kVK_Space:
-            // If it's the spacebar, handle logic around flipping the keyboard or just typing a regular space
-            if type == .keyDown {
-                if isSpaceDown { return nil }
-                isSpaceDown = true
-                return nil
-            }
-            else if type == .keyUp {
-                isSpaceDown = false
-                if typedCharacterWhileSpaceWasDown {
-                    typedCharacterWhileSpaceWasDown = false
-                    return nil
-                }
-                else {
-                    // simulate a key down so we type a space when space is released
-                    return CGEvent(
-                        keyboardEventSource: CGEventSource(event: event),
-                        virtualKey: CGKeyCode(kVK_Space),
-                        keyDown: true
-                    ).map(Unmanaged.passRetained) ?? Unmanaged.passUnretained(event)
-                }
-            }
-            return Unmanaged.passUnretained(event)
-        default:
-            if isSpaceDown {
-                // Space is currently pressed, so flip the keyboard using the mapping table
-                typedCharacterWhileSpaceWasDown = true
-
-                // Get the flipped-layout character from the mapping table
-                guard let newKeyCode = mapping[typedKeyCode] else {
-                    return Unmanaged.passUnretained(event)
-                }
-
-                // Construct a new event, as though the user had typed the flipped key
-                let newEvent = CGEvent(
-                    keyboardEventSource: CGEventSource(event: event),
-                    virtualKey: CGKeyCode(newKeyCode),
-                    keyDown: type == .keyDown
-                )
-                // fall back to original event if we failed to create a new one
-                return newEvent.map(Unmanaged.passRetained) ?? Unmanaged.passUnretained(event)
-            }
-            else {
-                // Space isn't down, so pass through the original keypress without changing it
-                return Unmanaged.passUnretained(event)
-            }
-        }
-    }
-
 }
-
-private let mapping: [Int: Int] = [
-    kVK_ANSI_A: kVK_ANSI_Semicolon,
-    kVK_ANSI_S: kVK_ANSI_L,
-    kVK_ANSI_D: kVK_ANSI_K,
-    kVK_ANSI_F: kVK_ANSI_J,
-    kVK_ANSI_H: kVK_ANSI_G,
-    kVK_ANSI_G: kVK_ANSI_H,
-    kVK_ANSI_Z: kVK_ANSI_Slash,
-    kVK_ANSI_X: kVK_ANSI_Period,
-    kVK_ANSI_C: kVK_ANSI_Comma,
-    kVK_ANSI_V: kVK_ANSI_M,
-    kVK_ANSI_B: kVK_ANSI_N,
-    kVK_ANSI_Q: kVK_ANSI_P,
-    kVK_ANSI_W: kVK_ANSI_O,
-    kVK_ANSI_E: kVK_ANSI_I,
-    kVK_ANSI_R: kVK_ANSI_U,
-    kVK_ANSI_Y: kVK_ANSI_T,
-    kVK_ANSI_T: kVK_ANSI_Y,
-    kVK_ANSI_O: kVK_ANSI_W,
-    kVK_ANSI_U: kVK_ANSI_R,
-    kVK_ANSI_I: kVK_ANSI_E,
-    kVK_ANSI_P: kVK_ANSI_Q,
-    kVK_ANSI_L: kVK_ANSI_S,
-    kVK_ANSI_J: kVK_ANSI_F,
-    kVK_ANSI_K: kVK_ANSI_D,
-    kVK_ANSI_Semicolon: kVK_ANSI_A,
-    kVK_ANSI_Comma: kVK_ANSI_C,
-    kVK_ANSI_Slash: kVK_ANSI_Z,
-    kVK_ANSI_N: kVK_ANSI_B,
-    kVK_ANSI_M: kVK_ANSI_V,
-    kVK_ANSI_Period: kVK_ANSI_X,
-    kVK_Tab: kVK_Delete,
-    kVK_ANSI_Backslash: kVK_Tab,
-
-    // Top row
-    kVK_ANSI_Grave: kVK_ANSI_Minus,
-    kVK_ANSI_1: kVK_ANSI_0,
-    kVK_ANSI_2: kVK_ANSI_9,
-    kVK_ANSI_3: kVK_ANSI_8,
-    kVK_ANSI_4: kVK_ANSI_7,
-    kVK_ANSI_5: kVK_ANSI_6,
-    kVK_ANSI_6: kVK_ANSI_5,
-    kVK_ANSI_7: kVK_ANSI_4,
-    kVK_ANSI_8: kVK_ANSI_3,
-    kVK_ANSI_9: kVK_ANSI_2,
-    kVK_ANSI_0: kVK_ANSI_1,
-    kVK_ANSI_Minus: kVK_ANSI_Grave,
-    kVK_ANSI_Equal: kVK_ANSI_Grave,
-
-    // TODO: punctuation, caps lock, return
-]

--- a/HalfKeyboard/EventHandler.swift
+++ b/HalfKeyboard/EventHandler.swift
@@ -32,7 +32,13 @@ final class EventHandler {
                 return Unmanaged.passRetained(event)
             }
             let unsafeProcessor = Unmanaged<KeyProcessor>.fromOpaque(userInfo).takeUnretainedValue()
-            return unsafeProcessor.process(event: event, type: type)
+            let events = unsafeProcessor.process(event: event, type: type)
+            events?.extras.forEach { event in
+                DispatchQueue.main.async {
+                    event.takeRetainedValue().post(tap: .cgSessionEventTap)
+                }
+            }
+            return events?.main
         }
 
         // Set up the tap to intercept events

--- a/Packages/.gitignore
+++ b/Packages/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Packages",
+    platforms: [
+        .macOS(.v10_13),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "KeyProcessor",
+            targets: ["KeyProcessor"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "KeyProcessor",
+            dependencies: []),
+        .testTarget(
+            name: "KeyProcessorTests",
+            dependencies: ["KeyProcessor"]),
+    ]
+)

--- a/Packages/README.md
+++ b/Packages/README.md
@@ -1,0 +1,7 @@
+# Packages
+
+Packages used to build this app.
+
+## KeyProcessor
+
+State machine that handles key press events. Factored out so it can be tested.

--- a/Packages/Sources/KeyProcessor/KeyProcessor.swift
+++ b/Packages/Sources/KeyProcessor/KeyProcessor.swift
@@ -32,10 +32,8 @@ public final class KeyProcessor {
     public init() {}
 
     public func process(event: CGEvent, type: CGEventType) -> Events? {
-        print(event)
         let unmodifiedEvent = { () -> Events? in
             let unmodified = Events(Unmanaged.passUnretained(event))
-            print("passing event unmodified: \(unmodified)")
             return unmodified
         }
         let typedKeyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
@@ -43,13 +41,11 @@ public final class KeyProcessor {
         case kVK_Space:
             // If it's the spacebar, handle logic around flipping the keyboard or just typing a regular space
             if type == .keyDown {
-                print("space down")
                 if isSpaceDown { return nil }
                 isSpaceDown = true
                 return nil
             }
             else if type == .keyUp {
-                print("space up")
                 isSpaceDown = false
                 if typedCharacterWhileSpaceWasDown {
                     typedCharacterWhileSpaceWasDown = false

--- a/Packages/Sources/KeyProcessor/KeyProcessor.swift
+++ b/Packages/Sources/KeyProcessor/KeyProcessor.swift
@@ -4,6 +4,10 @@ public struct Events {
     public let main: Unmanaged<CGEvent>?
     public let extras: [Unmanaged<CGEvent>]
 
+    var all: [Unmanaged<CGEvent>] {
+        ([main] + extras).compactMap { $0 }
+    }
+
     public init(_ main: Unmanaged<CGEvent>?) {
         self.init(main, extras: [])
     }

--- a/Packages/Sources/KeyProcessor/KeyProcessor.swift
+++ b/Packages/Sources/KeyProcessor/KeyProcessor.swift
@@ -1,0 +1,112 @@
+import Carbon.HIToolbox
+
+public final class KeyProcessor {
+    private var isSpaceDown = false
+    private var typedCharacterWhileSpaceWasDown = false
+
+    public init() {}
+
+    public func process(event: CGEvent, type: CGEventType) -> Unmanaged<CGEvent>? {
+        let typedKeyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        switch typedKeyCode {
+        case kVK_Space:
+            // If it's the spacebar, handle logic around flipping the keyboard or just typing a regular space
+            if type == .keyDown {
+                if isSpaceDown { return nil }
+                isSpaceDown = true
+                return nil
+            }
+            else if type == .keyUp {
+                isSpaceDown = false
+                if typedCharacterWhileSpaceWasDown {
+                    typedCharacterWhileSpaceWasDown = false
+                    return nil
+                }
+                else {
+                    // simulate a key down so we type a space when space is released
+                    return CGEvent(
+                        keyboardEventSource: CGEventSource(event: event),
+                        virtualKey: CGKeyCode(kVK_Space),
+                        keyDown: true
+                    ).map(Unmanaged.passRetained) ?? Unmanaged.passUnretained(event)
+                }
+            }
+            return Unmanaged.passUnretained(event)
+        default:
+            if isSpaceDown {
+                // Space is currently pressed, so flip the keyboard using the mapping table
+                typedCharacterWhileSpaceWasDown = true
+
+                // Get the flipped-layout character from the mapping table
+                guard let newKeyCode = mapping[typedKeyCode] else {
+                    return Unmanaged.passUnretained(event)
+                }
+
+                // Construct a new event, as though the user had typed the flipped key
+                let newEvent = CGEvent(
+                    keyboardEventSource: CGEventSource(event: event),
+                    virtualKey: CGKeyCode(newKeyCode),
+                    keyDown: type == .keyDown
+                )
+                // fall back to original event if we failed to create a new one
+                return newEvent.map(Unmanaged.passRetained) ?? Unmanaged.passUnretained(event)
+            }
+            else {
+                // Space isn't down, so pass through the original keypress without changing it
+                return Unmanaged.passUnretained(event)
+            }
+        }
+    }
+}
+
+private let mapping: [Int: Int] = [
+    kVK_ANSI_A: kVK_ANSI_Semicolon,
+    kVK_ANSI_S: kVK_ANSI_L,
+    kVK_ANSI_D: kVK_ANSI_K,
+    kVK_ANSI_F: kVK_ANSI_J,
+    kVK_ANSI_H: kVK_ANSI_G,
+    kVK_ANSI_G: kVK_ANSI_H,
+    kVK_ANSI_Z: kVK_ANSI_Slash,
+    kVK_ANSI_X: kVK_ANSI_Period,
+    kVK_ANSI_C: kVK_ANSI_Comma,
+    kVK_ANSI_V: kVK_ANSI_M,
+    kVK_ANSI_B: kVK_ANSI_N,
+    kVK_ANSI_Q: kVK_ANSI_P,
+    kVK_ANSI_W: kVK_ANSI_O,
+    kVK_ANSI_E: kVK_ANSI_I,
+    kVK_ANSI_R: kVK_ANSI_U,
+    kVK_ANSI_Y: kVK_ANSI_T,
+    kVK_ANSI_T: kVK_ANSI_Y,
+    kVK_ANSI_O: kVK_ANSI_W,
+    kVK_ANSI_U: kVK_ANSI_R,
+    kVK_ANSI_I: kVK_ANSI_E,
+    kVK_ANSI_P: kVK_ANSI_Q,
+    kVK_ANSI_L: kVK_ANSI_S,
+    kVK_ANSI_J: kVK_ANSI_F,
+    kVK_ANSI_K: kVK_ANSI_D,
+    kVK_ANSI_Semicolon: kVK_ANSI_A,
+    kVK_ANSI_Comma: kVK_ANSI_C,
+    kVK_ANSI_Slash: kVK_ANSI_Z,
+    kVK_ANSI_N: kVK_ANSI_B,
+    kVK_ANSI_M: kVK_ANSI_V,
+    kVK_ANSI_Period: kVK_ANSI_X,
+    kVK_Tab: kVK_Delete,
+    kVK_ANSI_Backslash: kVK_Tab,
+
+    // Top row
+    kVK_ANSI_Grave: kVK_ANSI_Minus,
+    kVK_ANSI_1: kVK_ANSI_0,
+    kVK_ANSI_2: kVK_ANSI_9,
+    kVK_ANSI_3: kVK_ANSI_8,
+    kVK_ANSI_4: kVK_ANSI_7,
+    kVK_ANSI_5: kVK_ANSI_6,
+    kVK_ANSI_6: kVK_ANSI_5,
+    kVK_ANSI_7: kVK_ANSI_4,
+    kVK_ANSI_8: kVK_ANSI_3,
+    kVK_ANSI_9: kVK_ANSI_2,
+    kVK_ANSI_0: kVK_ANSI_1,
+    kVK_ANSI_Minus: kVK_ANSI_Grave,
+    kVK_ANSI_Equal: kVK_ANSI_Grave,
+
+    // TODO: punctuation, caps lock, return
+]

--- a/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
+++ b/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
@@ -1,7 +1,106 @@
+import Carbon.HIToolbox
 import XCTest
 @testable import KeyProcessor
 
 final class KeyProcessorTests: XCTestCase {
-    func testExample() {
+
+    func testLefRegularKeyDown() throws {
+        let sut = KeyProcessor()
+        try sut.assert(keyCode: kVK_ANSI_A, type: .keyDown, expected: (kVK_ANSI_A, .keyDown))
+        try sut.assert(keyCode: kVK_ANSI_A, type: .keyUp, expected: (kVK_ANSI_A, .keyUp))
+    }
+
+    func testRightRegularKeyDown() throws {
+        let sut = KeyProcessor()
+        try sut.assert(keyCode: kVK_ANSI_O, type: .keyDown, expected: (kVK_ANSI_O, .keyDown))
+        try sut.assert(keyCode: kVK_ANSI_O, type: .keyUp, expected: (kVK_ANSI_O, .keyUp))
+    }
+
+    func testSpacebar() throws {
+        XCTExpectFailure("Spacebar is currently faking it by sending .keyDown when the user does a keyUp. Works because typing happens on key down, not key up, but it probably leaves the OS in a confused state because it thinks the spacebar is down. Will fix in a future change.")
+        let sut = KeyProcessor()
+        try sut.assert(keyCode: kVK_Space, type: .keyDown, expected: nil)
+        try sut.assert(keyCode: kVK_Space, type: .keyUp, expected: (kVK_Space, .keyUp))
+    }
+
+    func testLeftFlippedKeyDown() throws {
+        let sut = KeyProcessor()
+        try sut.assert(keyCode: kVK_Space, type: .keyDown, expected: nil)
+        try sut.assert(keyCode: kVK_ANSI_S, type: .keyDown, expected: (kVK_ANSI_L, .keyDown))
+        try sut.assert(keyCode: kVK_ANSI_S, type: .keyUp, expected: (kVK_ANSI_L, .keyUp))
+        try sut.assert(keyCode: kVK_Space, type: .keyUp, expected: nil)
+    }
+
+}
+
+private enum EventType {
+    case keyDown
+    case keyUp
+
+    var isKeyDown: Bool {
+        switch self {
+        case .keyDown: return true
+        case .keyUp: return false
+        }
+    }
+
+    var eventType: CGEventType {
+        switch self {
+        case .keyDown: return .keyDown
+        case .keyUp: return .keyUp
+        }
+    }
+}
+
+private extension KeyProcessor {
+    func assert(keyCode: Int, type: EventType, expected: (keyCode: Int, type: CGEventType)?, file: StaticString = #filePath, line: UInt = #line) throws {
+        let fakeEvent = try XCTUnwrap(
+            CGEvent(
+                keyboardEventSource: CGEventSource(stateID: .hidSystemState),
+                virtualKey: CGKeyCode(keyCode),
+                keyDown: type.isKeyDown
+            ).map(Unmanaged.passRetained)
+        )
+        let event = process(event: fakeEvent.takeUnretainedValue(), type: type.eventType)?.takeRetainedValue()
+        if let expected = expected {
+            if let event = event {
+                XCTAssertEqual(event.getIntegerValueField(.keyboardEventKeycode), Int64(expected.keyCode), "keycode not equal", file: file, line: line)
+                XCTAssertEqual(event.type.humanReadable, expected.type.humanReadable, "event type not equal", file: file, line: line)
+            }
+            else {
+                XCTFail("Got nil, but expected \(expected)")
+            }
+        }
+        else {
+            XCTAssertNil(event)
+        }
+    }
+}
+
+extension CGEventType {
+    var humanReadable: String {
+        switch self {
+        case .null: return "null"
+        case .leftMouseDown: return "leftMouseDown"
+        case .leftMouseUp: return "leftMouseUp"
+        case .rightMouseDown: return "rightMouseDown"
+        case .rightMouseUp: return "rightMouseUp"
+        case .mouseMoved: return "mouseMoved"
+        case .leftMouseDragged: return "leftMouseDragged"
+        case .rightMouseDragged: return "rightMouseDragged"
+        case .keyDown: return "keyDown"
+        case .keyUp: return "keyUp"
+        case .flagsChanged: return "flagsChanged"
+        case .scrollWheel: return "scrollWheel"
+        case .tabletPointer: return "tabletPointer"
+        case .tabletProximity: return "tabletProximity"
+        case .otherMouseDown: return "otherMouseDown"
+        case .otherMouseUp: return "otherMouseUp"
+        case .otherMouseDragged: return "otherMouseDragged"
+        case .tapDisabledByTimeout: return "tapDisabledByTimeout"
+        case .tapDisabledByUserInput: return "tapDisabledByUserInput"
+        @unknown default:
+            return "unknown case \(self.rawValue)"
+        }
     }
 }

--- a/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
+++ b/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
@@ -30,6 +30,20 @@ final class KeyProcessorTests: XCTestCase {
         try sut.assert(keyCode: kVK_Space, type: .keyUp, expected: [])
     }
 
+    func testSpaceWorksAfterCommandSpace() throws {
+        let sut = KeyProcessor()
+
+        // command-space shortcut
+        try sut.assert(keyCode: kVK_Command, type: .keyDown, expected: [(kVK_Command, .flagsChanged)])
+        try sut.assert(keyCode: kVK_Space, type: .keyDown, expected: [])
+        try sut.assert(keyCode: kVK_Space, type: .keyUp, expected: [(kVK_Space, .keyDown), (kVK_Space, .keyUp)])
+        try sut.assert(keyCode: kVK_Command, type: .keyUp, expected: [(kVK_Command, .flagsChanged)])
+
+        // type a space
+        try sut.assert(keyCode: kVK_Space, type: .keyDown, expected: [])
+        try sut.assert(keyCode: kVK_Space, type: .keyUp, expected: [(kVK_Space, .keyDown), (kVK_Space, .keyUp)])
+    }
+
 }
 
 private enum EventType {

--- a/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
+++ b/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
@@ -17,10 +17,9 @@ final class KeyProcessorTests: XCTestCase {
     }
 
     func testSpacebar() throws {
-        XCTExpectFailure("Spacebar is currently faking it by sending .keyDown when the user does a keyUp. Works because typing happens on key down, not key up, but it probably leaves the OS in a confused state because it thinks the spacebar is down. Will fix in a future change.")
         let sut = KeyProcessor()
         try sut.assert(keyCode: kVK_Space, type: .keyDown, expected: [])
-        try sut.assert(keyCode: kVK_Space, type: .keyUp, expected: [(kVK_Space, .keyUp)])
+        try sut.assert(keyCode: kVK_Space, type: .keyUp, expected: [(kVK_Space, .keyDown), (kVK_Space, .keyUp)])
     }
 
     func testLeftFlippedKeyDown() throws {

--- a/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
+++ b/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import KeyProcessor
+
+final class KeyProcessorTests: XCTestCase {
+    func testExample() {
+    }
+}

--- a/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
+++ b/Packages/Tests/KeyProcessorTests/KeyProcessorTests.swift
@@ -61,18 +61,18 @@ private extension KeyProcessor {
                 keyDown: type.isKeyDown
             ).map(Unmanaged.passRetained)
         )
-        let event = process(event: fakeEvent.takeUnretainedValue(), type: type.eventType)?.takeRetainedValue()
+        let events = process(event: fakeEvent.takeUnretainedValue(), type: type.eventType)
         if let expected = expected {
-            if let event = event {
-                XCTAssertEqual(event.getIntegerValueField(.keyboardEventKeycode), Int64(expected.keyCode), "keycode not equal", file: file, line: line)
-                XCTAssertEqual(event.type.humanReadable, expected.type.humanReadable, "event type not equal", file: file, line: line)
+            if let mainEvent = events?.main?.takeUnretainedValue() {
+                XCTAssertEqual(mainEvent.getIntegerValueField(.keyboardEventKeycode), Int64(expected.keyCode), "keycode not equal", file: file, line: line)
+                XCTAssertEqual(mainEvent.type.humanReadable, expected.type.humanReadable, "event type not equal", file: file, line: line)
             }
             else {
                 XCTFail("Got nil, but expected \(expected)")
             }
         }
         else {
-            XCTAssertNil(event)
+            XCTAssertNil(events)
         }
     }
 }


### PR DESCRIPTION
Fixes #3.

- Split key processor out into separate framework and add tests.
- Fix issue where we were never sending a space-up event, resulting in the spacebar getting stuck. Also fixes an issue where Command-Space was broken in apps like LaunchBar.